### PR TITLE
fix: updated package.json for windows users

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "react-scripts": "3.4.1"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
+    "start": "craco --max_old_space_size=4096 start",
+    "build": "craco --max_old_space_size=4096 build",
     "test": "craco test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject",
     "prettier": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",


### PR DESCRIPTION
craco start/craco build script were were causing JavaScrip heap overloads. Added `--max_old_space_size=4096` to both scripts to allocate more memory. 

Fix was found here: 
https://stackoverflow.com/questions/55613789/how-to-fix-fatal-error-ineffective-mark-compacts-near-heap-limit-allocation-fa
