### PR TITLE
Feat: Created (Mobile-View) Carousel for Graphs

### DIFF
--- a/src/components/graphs/GraphCarousel.js
+++ b/src/components/graphs/GraphCarousel.js
@@ -1,0 +1,60 @@
+import React, { useState, useEffect } from 'react';
+import SavingsGraph from './SavingsGraph';
+import Budgets from './Budgets';
+import ComparedSavings from './ComparedSavings';
+import ComparedSpendings from './ComparedSpendings';
+
+function GraphCarousel() {
+  // created an index to determine which graph to display, and set a default graph to state
+  const [index, setIndex] = useState(0);
+  const [graph, setGraph] = useState(<SavingsGraph />);
+
+  // re-render the graph every time the index changes
+  useEffect(() => {
+    renderGraph();
+  }, [index]);
+
+  // modifies the graph state to be correlated to the current index
+  const renderGraph = () => {
+    if (index === 0) {
+      setGraph(<SavingsGraph />);
+    } else if (index === 1) {
+      setGraph(<Budgets />);
+    } else if (index === 2) {
+      setGraph(<ComparedSavings />);
+    } else if (index === 3) {
+      setGraph(<ComparedSpendings />);
+    }
+  };
+
+  // left and right functions serve to increase or decrease the index, and handle the index from going out of range
+  const indexLeft = () => {
+    index - 1 < 0 ? setIndex(3) : setIndex(index - 1);
+  };
+  const indexRight = () => {
+    index + 1 > 3 ? setIndex(0) : setIndex(index + 1);
+  };
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          indexLeft();
+        }}
+      >
+        {' '}
+        &#60;{' '}
+      </button>
+      {graph}
+      <button
+        onClick={() => {
+          indexRight();
+        }}
+      >
+        &#62;
+      </button>
+    </div>
+  );
+}
+
+export default GraphCarousel;

--- a/src/components/graphs/index.js
+++ b/src/components/graphs/index.js
@@ -3,3 +3,4 @@ export { default as SavingsGraph } from './SavingsGraph';
 export { default as Budgets } from './Budgets';
 export { default as ComparedSavings } from './ComparedSavings';
 export { default as ComparedSpendings } from './ComparedSpendings';
+export { default as GraphCarousel } from './GraphCarousel';

--- a/src/components/pages/Home/RenderHomePage.js
+++ b/src/components/pages/Home/RenderHomePage.js
@@ -6,24 +6,39 @@ import {
   Budgets,
   ComparedSavings,
   ComparedSpendings,
+  GraphCarousel,
 } from '../../graphs';
 import Nav from '../Nav/Nav';
 
 function RenderHomePage(props) {
   const { userInfo, authService } = props;
+
+  // this function gets the width of the page, and renders either the graph carousel (mobile) or all of the graphs individually (desktop)
+  const renderGraphs = () => {
+    const screenWidth = window.innerWidth;
+    if (screenWidth > 765) {
+      return (
+        <>
+          <SavingsGraph />
+
+          <Budgets />
+
+          <ComparedSavings />
+
+          <ComparedSpendings />
+        </>
+      );
+    } else {
+      return <GraphCarousel />;
+    }
+  };
   return (
     <div>
       <Nav authService={authService} />
       <h1>Hi {userInfo.name} Welcome to your SaverLife Dashboard!</h1>
       <div>
         <p>Here is your spendings and savings history in graphs.</p>
-        <SavingsGraph />
-
-        <Budgets />
-
-        <ComparedSavings />
-
-        <ComparedSpendings />
+        {renderGraphs()}
 
         <p>
           <Link to="/profile-list">Profiles Example</Link>


### PR DESCRIPTION
### **Heading/Title**
Created a carousel for the graphs in mobile view

**Description**
Created a component to show only one graph at a time for mobile view to keep the page clean.
It will only render the component if the page is less than 765px wide, otherwise it will display all 4 graphs individually
Currently uses buttons to switch between graphs, looking into implementing swipe gestures for mobile use

Modified the RenderHomePage component to have the graphs render in a function, opposed to just being inside of the return statement, that way there could be control over whether to render the carousel or all 4 individual graphs


**Fixes** 
Cleaned up the page a bit for mobile use. 4 graphs on one page made the page look very busy on the mobile view. Rending 4 graphs at a time might also cause the page to render slower on a non-ideal internet connection

**Type of Change**
Feature