### PR TITLE
Chore: userInfo passed as props to Graph Methods

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,7 +9,7 @@ const getAuthHeader = authState => {
   return { Authorization: `Bearer ${authState.idToken}` };
 };
 
-const getSpending = (url, authState) => {
+const getSpending = (url, authState, userInfo) => {
   const headers = getAuthHeader(authState);
   if (!url) {
     throw new Error('No URL provided');
@@ -18,7 +18,7 @@ const getSpending = (url, authState) => {
     .post(
       url,
       {
-        user_id: '00ulthapbErVUwVJy4x6',
+        user_id: `${userInfo.sub}`,
         time_period: 'week',
         graph_type: 'pie',
         color_template: 'dense',
@@ -30,7 +30,7 @@ const getSpending = (url, authState) => {
     .catch(err => err);
 };
 
-const getSpendingBar = (url, authState) => {
+const getSpendingBar = (url, authState, userInfo) => {
   const headers = getAuthHeader(authState);
   if (!url) {
     throw new Error('No URL provided');
@@ -39,7 +39,7 @@ const getSpendingBar = (url, authState) => {
     .post(
       url,
       {
-        user_id: '00ulthapbErVUwVJy4x6',
+        user_id: `${userInfo.sub}`,
         time_period: 'week',
         graph_type: 'bar',
         color_template: 'Burg',
@@ -50,7 +50,7 @@ const getSpendingBar = (url, authState) => {
     .catch(err => err);
 };
 
-const getMoneyFlow = (url, authState) => {
+const getMoneyFlow = (url, authState, userInfo) => {
   const headers = getAuthHeader(authState);
   if (!url) {
     throw new Error('No URL provided');
@@ -59,7 +59,7 @@ const getMoneyFlow = (url, authState) => {
     .post(
       url,
       {
-        user_id: '00ulthapbErVUwVJy4x6',
+        user_id: `${userInfo.sub}`,
         time_period: 'week',
       },
       { headers }
@@ -68,9 +68,9 @@ const getMoneyFlow = (url, authState) => {
     .catch(err => err);
 };
 
-const getFutureBudget = (url, authState) => {
+const getFutureBudget = (url, authState, userInfo) => {
   var headers = getAuthHeader(authState);
-  var headers = { ...headers, user_id: '00ulthapbErVUwVJy4x6' };
+  var headers = { ...headers, user_id: `${userInfo.sub}` };
   console.log(headers);
   if (!url) {
     throw new Error('No URL provided');
@@ -81,7 +81,7 @@ const getFutureBudget = (url, authState) => {
     .catch(err => err);
 };
 
-const postFutureBudget = (url, authState) => {
+const postFutureBudget = (url, authState, userInfo) => {
   const headers = getAuthHeader(authState);
   if (!url) {
     throw new Error('No URL provided');
@@ -90,7 +90,7 @@ const postFutureBudget = (url, authState) => {
     .post(
       url,
       {
-        user_id: '00ulthapbErVUwVJy4x6',
+        user_id: `${userInfo.sub}`,
         monthly_savings_goal: 400,
         placeholder: 'Shopping, Auto, Utilities',
       },

--- a/src/components/graphs/Budgets.js
+++ b/src/components/graphs/Budgets.js
@@ -12,7 +12,7 @@ function Budgets(props) {
 
   useEffect(() => {
     function fetchDSData() {
-      getFutureBudget(props.url, props.authState)
+      getFutureBudget(props.url, props.authState, props.userInfo)
         .then(res => {
           setData(res);
         })
@@ -22,7 +22,7 @@ function Budgets(props) {
         });
     }
     fetchDSData();
-  }, [props.url, props.authState]);
+  }, [props.url, props.authState, props.userInfo]);
 
   const checkProgressColor = percentage => {
     if (percentage < 50) {

--- a/src/components/graphs/MoneyFlow.js
+++ b/src/components/graphs/MoneyFlow.js
@@ -13,7 +13,7 @@ function MoneyFlow(props) {
 
   useEffect(() => {
     function fetchDSData() {
-      getMoneyFlow(props.url, props.authState)
+      getMoneyFlow(props.url, props.authState, props.userInfo)
         .then(res => {
           setData(res);
         })
@@ -23,7 +23,7 @@ function MoneyFlow(props) {
         });
     }
     fetchDSData();
-  }, [props.url, props.authState]);
+  }, [props.url, props.authState, props.userInfo]);
 
   return (
     <MoneyFlowContainer>

--- a/src/components/graphs/RenderGraphs.js
+++ b/src/components/graphs/RenderGraphs.js
@@ -10,11 +10,8 @@ import {
 import Media from 'react-media';
 import { RenderGraphWrapper } from './styles/GraphStyles';
 
-import { useOktaAuth } from '@okta/okta-react/dist/OktaContext';
-
-const RenderGraphs = () => {
-  const { authState } = useOktaAuth();
-
+const RenderGraphs = props => {
+  const { userInfo, authState } = props;
   return (
     <>
       <Media
@@ -23,21 +20,25 @@ const RenderGraphs = () => {
           <>
             <MoneyFlow
               authState={authState}
+              userInfo={userInfo}
               url={process.env.REACT_APP_API_URI + 'data/moneyflow'}
             />
 
             <SpendingPost
               authState={authState}
+              userInfo={userInfo}
               url={process.env.REACT_APP_API_URI + 'data/spending'}
             />
 
             <SpendingPostBar
               authState={authState}
+              userInfo={userInfo}
               url={process.env.REACT_APP_API_URI + 'data/spending'}
             />
 
             <Budgets
               authState={authState}
+              userInfo={userInfo}
               url={process.env.REACT_APP_API_URI + 'data/futureBudget'}
             />
 
@@ -52,18 +53,21 @@ const RenderGraphs = () => {
             <RenderGraphWrapper>
               <MoneyFlow
                 authState={authState}
+                userInfo={userInfo}
                 url={process.env.REACT_APP_API_URI + 'data/moneyflow'}
               />
             </RenderGraphWrapper>
             <RenderGraphWrapper>
               <SpendingPost
                 authState={authState}
+                userInfo={userInfo}
                 url={process.env.REACT_APP_API_URI + 'data/spending'}
               />
             </RenderGraphWrapper>
             <RenderGraphWrapper>
               <Budgets
                 authState={authState}
+                userInfo={userInfo}
                 url={process.env.REACT_APP_API_URI + 'data/futureBudget'}
               />
             </RenderGraphWrapper>
@@ -74,6 +78,7 @@ const RenderGraphs = () => {
             <RenderGraphWrapper>
               <SpendingPostBar
                 authState={authState}
+                userInfo={userInfo}
                 url={process.env.REACT_APP_API_URI + 'data/spending'}
               />
             </RenderGraphWrapper>

--- a/src/components/graphs/SpendingPost.js
+++ b/src/components/graphs/SpendingPost.js
@@ -13,7 +13,7 @@ function SpendingPost(props) {
 
   useEffect(() => {
     function fetchDSData() {
-      getSpending(props.url, props.authState)
+      getSpending(props.url, props.authState, props.userInfo)
         .then(res => {
           setData(res);
         })
@@ -22,7 +22,7 @@ function SpendingPost(props) {
         });
     }
     fetchDSData();
-  }, [props.url, props.authState]);
+  }, [props.url, props.authState, props.userInfo]);
 
   return (
     <SpendingContainer>

--- a/src/components/graphs/SpendingPostBar.js
+++ b/src/components/graphs/SpendingPostBar.js
@@ -13,7 +13,7 @@ function SpendingPostBar(props) {
 
   useEffect(() => {
     function fetchDSData() {
-      getSpendingBar(props.url, props.authState)
+      getSpendingBar(props.url, props.authState, props.userInfo)
         .then(res => {
           setData(res);
         })
@@ -22,7 +22,7 @@ function SpendingPostBar(props) {
         });
     }
     fetchDSData();
-  }, [props.url, props.authState]);
+  }, [props.url, props.authState, props.userInfo]);
 
   return (
     <SpendingBarContainer>

--- a/src/components/pages/Home/HomeContainer.js
+++ b/src/components/pages/Home/HomeContainer.js
@@ -27,14 +27,17 @@ function HomeContainer({ LoadingComponent }) {
       });
     return () => (isSubscribed = false);
   }, [memoAuthService]);
-
   return (
     <>
       {authState.isAuthenticated && !userInfo && (
         <LoadingComponent message="Fetching user profile..." />
       )}
       {authState.isAuthenticated && userInfo && (
-        <RenderHomePage userInfo={userInfo} authService={authService} />
+        <RenderHomePage
+          userInfo={userInfo}
+          authService={authService}
+          authState={authState}
+        />
       )}
     </>
   );

--- a/src/components/pages/Home/RenderHomePage.js
+++ b/src/components/pages/Home/RenderHomePage.js
@@ -4,7 +4,7 @@ import RenderGraphs from '../../graphs/RenderGraphs';
 import { HomeWrapper, HeaderContainer } from './styles/HomeStyles';
 
 function RenderHomePage(props) {
-  const { userInfo, authService } = props;
+  const { userInfo, authService, authState } = props;
 
   return (
     <HomeWrapper>
@@ -13,7 +13,7 @@ function RenderHomePage(props) {
         <h1>Here is your spendings and savings history in graphs.</h1>
       </HeaderContainer>
 
-      <RenderGraphs />
+      <RenderGraphs userInfo={userInfo} authState={authState} />
     </HomeWrapper>
   );
 }


### PR DESCRIPTION
Heading/Title

UserInfo/UserId Passed to Graph Methods

Description

- Used getUser() method on the authService object in HomeContainer.js to get user's profile. Passed down the user's profile (userInfo) as props to the RenderHomePage.js component in HomeContainer.js.

- In RenderHomePage took userInfo and authState from props and passed to RenderGraphs. RenderGraphs then passes authState and userInfo from props to each graph component (MoneyFlow, Spending Post ..etc)

- Each graph component calls a method from api/index.js and passes userInfo as an argument. For each method (getSpending, getMoneyFlow,...etc) userInfo.sub is used as in a template literal as the value for the user_id. 


Type of Change

Chore Passed userInfo as Props to Graph methods